### PR TITLE
parameterized python patcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+manifest.yml
 downloads/
 downloads.tar.bz2

--- a/examples/patch_python_extension.py
+++ b/examples/patch_python_extension.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import argparse
+from glob import glob
+import json
+from os.path import join
+
+def activate_on_start(extension_path):
+    package_json = join(extension_path, 'package.json')
+
+    with open(package_json, 'rt') as f:
+        pkg = json.load(f)
+
+    ## Python extension will activate when the editor loads
+    pkg['activationEvents'].insert(0, 'workspaceContains:**/anaconda-project.yml')
+
+    with open(package_json, 'wt') as f:
+        json.dump(pkg, f)
+
+
+def preparing_env(extension_path):
+    ## Indicate that environment is being prepared
+    source = join(extension_path, 'out', 'client', 'extension.js')
+
+    with open(source, 'rt') as f:
+        js = f.read()
+
+    js = js.replace(' Select Python Interpreter', ' Preparing Environment...')
+
+    with open(source, 'wt') as f:
+        f.write(js)
+
+
+def cli():
+    parser = argparse.ArgumentParser(description='Patch the VSCode Python extension.')
+
+    parser.add_argument('extension_path', help='Path to the installed Python extension.')
+
+    parser.add_argument('--auto-start', help='Force the Python extension to start when the session loads.',
+                        action='store_true')
+    parser.add_argument('--preparing-env', help='Indicate that the environment is being prepared if not found.',
+                        action='store_true')
+
+    return parser
+
+def main(args):
+    if args.auto_start:
+        activate_on_start(args.extension_path)
+
+    if args.preparing_env:
+        preparing_env(args.extension_path)
+
+if __name__ == '__main__':
+    args = cli().parse_args()
+
+    main(args)

--- a/manifest.yml.example
+++ b/manifest.yml.example
@@ -9,7 +9,7 @@ extensions:
 
   - url: https://github.com/microsoft/vscode-python/releases/download/2020.4.74986/ms-python-release.vsix
     post_install:
-      - "/opt/continuum/anaconda/envs/lab_launch/bin/python patch_python_extension.py"
+      - "/opt/continuum/anaconda/envs/lab_launch/bin/python patch_python_extension.py /opt/continuum/.vscode/extensions/ms-python.python-2020.4.74986 --preparing-env"
 
 
 


### PR DESCRIPTION
the python patch script is included in the examples directory

```
usage: patch_python_extension.py [-h] [--auto-start] [--preparing-env]
                                 extension_path

Patch the VSCode Python extension.

positional arguments:
  extension_path   Path to the installed Python extension.

optional arguments:
  -h, --help       show this help message and exit
  --auto-start     Force the Python extension to start when the session loads.
  --preparing-env  Indicate that the environment is being prepared if not
                   found.
```