### PR TITLE
Defined manifest.yml for Aduno Gruppe demo

### DIFF
--- a/examples/manifest-Aduno.yml
+++ b/examples/manifest-Aduno.yml
@@ -1,4 +1,4 @@
-# Updates code-server to 3.4.1 and ms-python extension to 2020.5.86806
+# This manifest was built and tests on commit 3be407f
 
 patch_python_extension.py:
   - url: https://ae5-vscode-extensions.s3.amazonaws.com/patch_python_extension.py


### PR DESCRIPTION
This manifest.yml was used to demo to Aduno Gruppe, built using a checkout of 3be407f (one commit behind current master). 

The most tricky extensions were identical to those used for DNB (Intellicode, MSSQL, Gitlens) but a few of the more minor extensions were new, namely the autodocstring, yaml (RedHat), jinja, code-spell-checker, markdownlint and reflow-markdown extensions. These extensions have been tested, are known to be working and are now available in the S3 bucket.

