### PR TITLE
AENT-8263: Bump to code-server 4.90.1, python 2024.4.1

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,26 +3,26 @@
 # All downloads are placed in the "downloads" subdirectory.
 
 # code-server
-https://github.com/coder/code-server/releases/download/v4.22.1/code-server-4.22.1-linux-amd64.tar.gz
-ec40994776bbcb958d9efb328c1b61038167a8d5473c9c841b25df24578dc420
+https://github.com/coder/code-server/releases/download/v4.90.1/code-server-4.90.1-linux-amd64.tar.gz
+7a804a7510e8427303575c6d2918690b59e4be2f9749021e9475337ebd6ba1f2
 
 # ae5-session
 https://ae5-vscode.s3.amazonaws.com/ae5-session-0.3.2.vsix
 352fd515c975556ac8a4fa0c71b51388a21d0a93e2876332ac20b02a7092b594
 
 # python extension
-https://open-vsx.org/api/ms-python/python/2024.2.1/file/ms-python.python-2024.2.1.vsix
-801b6f6c78c6ea7a10a46db7414f5d5f32e11b395a577efde2e7206147a9283d
+https://open-vsx.org/api/ms-python/python/2024.4.1/file/ms-python.python-2024.4.1.vsix
+f6b8d5df6d54267fd5c7237a39e723cee6653514a78f5be0ad6d0e2ac49fbd24
 
 # jupyter extension
 # NOTE: the python extension must appear above this extension in the list,
 # and note not all versions of these two extensions are compatible with each other.
-https://open-vsx.org/api/ms-toolsai/jupyter/2023.9.100/file/ms-toolsai.jupyter-2023.9.100.vsix
-302c47f4bb552eb012e4925eedbad882b9a2982436470691b77a7ee35d41dc32
+https://open-vsx.org/api/ms-toolsai/jupyter/2024.5.0/file/ms-toolsai.jupyter-2024.5.0.vsix
+ec938d32e5d5fb97186e38435401502aa4143458ade6b6db236b74dc08aff83e
 
 # yaml extension by redhat
-https://open-vsx.org/api/redhat/vscode-yaml/1.14.0/file/redhat.vscode-yaml-1.14.0.vsix
-8424720c0ea8645ee126fd1899b346dd2d973ed35bcb15f58f7a8bd62c4e9c5f
+https://open-vsx.org/api/redhat/vscode-yaml/1.15.0/file/redhat.vscode-yaml-1.15.0.vsix
+36194b35826bc8a291bfea8f58e8fdea94f6c1f92241ea848a9dbbaf39760b43
 
 # If you have additional extensions, you may put them here, following the
 # same format. The download_vscode.sh script will download them, and the

--- a/MANIFEST
+++ b/MANIFEST
@@ -3,16 +3,16 @@
 # All downloads are placed in the "downloads" subdirectory.
 
 # code-server
-https://github.com/coder/code-server/releases/download/v4.20.0/code-server-4.20.0-linux-amd64.tar.gz
-e9bf305c6d4b3a6856244f1d9409366a9566de5cf6344c076a681a864a4085d4
+https://github.com/coder/code-server/releases/download/v4.22.1/code-server-4.22.1-linux-amd64.tar.gz
+ec40994776bbcb958d9efb328c1b61038167a8d5473c9c841b25df24578dc420
 
 # ae5-session
 https://ae5-vscode.s3.amazonaws.com/ae5-session-0.3.2.vsix
 352fd515c975556ac8a4fa0c71b51388a21d0a93e2876332ac20b02a7092b594
 
 # python extension
-https://open-vsx.org/api/ms-python/python/2023.22.1/file/ms-python.python-2023.22.1.vsix
-aa73601f8ae5e96a453d2a21dd3b4fdae09a92e09ccab6e5a00179d4919c18a3
+https://open-vsx.org/api/ms-python/python/2024.2.1/file/ms-python.python-2024.2.1.vsix
+801b6f6c78c6ea7a10a46db7414f5d5f32e11b395a577efde2e7206147a9283d
 
 # jupyter extension
 # NOTE: the python extension must appear above this extension in the list,


### PR DESCRIPTION
Just a simple minor version bump. Tested on Minikube.

To test:

- Download https://airgap.svc.anaconda.com/misc/vscode-installer-test.tar.bz2
- Upload into AE5
- Launch a session
- Run `download_vscode.sh`
- Run `install_vscode.sh`
- Stop the session
- Switch editor to Visual Studio Code
- Launch a new session