### PR TITLE
Workbench March Version updates

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,22 +3,22 @@
 # All downloads are placed in the "downloads" subdirectory.
 
 # code-server
-https://github.com/coder/code-server/releases/download/v4.96.4/code-server-4.96.4-linux-amd64.tar.gz
-b3f9025d00f2cdf61caf83945ef7225d4a3eb576c4c007e45868f45713e39c8e
+https://github.com/coder/code-server/releases/download/v4.98.2/code-server-4.98.2-linux-amd64.tar.gz
+ad73bbad1d46ecac5e159ece34412f0626d451d13c44d5758f08cc7603de40d5
 
 # ae5-session
 https://ae5-vscode.s3.amazonaws.com/ae5-session-0.3.2.vsix
 352fd515c975556ac8a4fa0c71b51388a21d0a93e2876332ac20b02a7092b594
 
 # python extension
-https://open-vsx.org/api/ms-python/python/2025.0.0/file/ms-python.python-2025.0.0.vsix
-aef68096228d6ede1f277a6a11b1443ef088a473eb798a31c9d02247f1795707
+https://open-vsx.org/api/ms-python/python/2025.2.0/file/ms-python.python-2025.2.0.vsix
+b6e7f640bc1b2a184597b518d8d5f73b447009a650c59fa5d2b1b4f68d19d9b1
 
 # jupyter extension
 # NOTE: the python extension must appear above this extension in the list,
 # and note not all versions of these two extensions are compatible with each other.
-https://open-vsx.org/api/ms-toolsai/jupyter/2025.1.0/file/ms-toolsai.jupyter-2025.1.0.vsix
-313a1f6889ae02f9f00ae0de50336193c7dc3e1764770d866b4fa4ad7eaa4876
+https://open-vsx.org/api/ms-toolsai/jupyter/2025.2.0/file/ms-toolsai.jupyter-2025.2.0.vsix
+5d3f3fb56c004dda88ef6fb636d80270ce687407d78c1b27c66242d9b6e4628e
 
 # yaml extension by redhat
 https://open-vsx.org/api/redhat/vscode-yaml/1.15.0/file/redhat.vscode-yaml-1.15.0.vsix

--- a/MANIFEST
+++ b/MANIFEST
@@ -4,7 +4,7 @@
 
 # code-server
 https://github.com/coder/code-server/releases/download/v4.98.2/code-server-4.98.2-linux-amd64.tar.gz
-ad73bbad1d46ecac5e159ece34412f0626d451d13c44d5758f08cc7603de40d5
+592acabf2f16210f4aec62d0390b2e3a392b7013068f97de72a14ce87d4279ff
 
 # ae5-session
 https://ae5-vscode.s3.amazonaws.com/ae5-session-0.3.2.vsix


### PR DESCRIPTION
March version updates for vscode. 

vscode
4.98.2

https://github.com/coder/code-server/releases/download/v4.98.2/code-server-4.98.2-linux-amd64.tar.gz

 

version / hash set here: [ae5-vscode/MANIFEST at master · anaconda/ae5-vscode](https://github.com/anaconda/ae5-vscode/blob/master/MANIFEST#L6-L7) 

 

python extension

2025.2.0

https://open-vsx.org/extension/ms-python/python/2025.2.0

https://open-vsx.org/api/ms-python/python/2025.2.0/file/ms-python.python-2025.2.0.vsix

 

version / hash set here: [ae5-vscode/MANIFEST at master · anaconda/ae5-vscode](https://github.com/anaconda/ae5-vscode/blob/master/MANIFEST#L14-L15) 

 

jupyter extension

2025.2.0

https://open-vsx.org/extension/ms-toolsai/jupyter/2025.2.0

https://open-vsx.org/api/ms-toolsai/jupyter/2025.2.0/file/ms-toolsai.jupyter-2025.2.0.vsix

 

version / hash set here: [ae5-vscode/MANIFEST at master · anaconda/ae5-vscode](https://github.com/anaconda/ae5-vscode/blob/master/MANIFEST#L20-L21)