### PR TITLE
AENT-8703: code-server 4.99.3, python 2025.4.0, jupyter 2025.3.0, yaml 1.17.0

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,26 +3,26 @@
 # All downloads are placed in the "downloads" subdirectory.
 
 # code-server
-https://github.com/coder/code-server/releases/download/v4.98.2/code-server-4.98.2-linux-amd64.tar.gz
-592acabf2f16210f4aec62d0390b2e3a392b7013068f97de72a14ce87d4279ff
+https://github.com/coder/code-server/releases/download/v4.99.3/code-server-4.99.3-linux-amd64.tar.gz
+b66d932142a1bae7ea58b13aac4de04f6e6c0a82c7da198b926904330c0ae9e3
 
 # ae5-session
 https://airgap-svc.s3.us-east-1.amazonaws.com/ae5/ae5-session-0.3.2.vsix
 352fd515c975556ac8a4fa0c71b51388a21d0a93e2876332ac20b02a7092b594
 
 # python extension
-https://open-vsx.org/api/ms-python/python/2025.2.0/file/ms-python.python-2025.2.0.vsix
-b6e7f640bc1b2a184597b518d8d5f73b447009a650c59fa5d2b1b4f68d19d9b1
+https://open-vsx.org/api/ms-python/python/2025.4.0/file/ms-python.python-2025.4.0.vsix
+31b22cdb399b0aaeb7705e8e38665e0c33ac3dacd13852a1a8b7fb151c728b72
 
 # jupyter extension
 # NOTE: the python extension must appear above this extension in the list,
 # and note not all versions of these two extensions are compatible with each other.
-https://open-vsx.org/api/ms-toolsai/jupyter/2025.2.0/file/ms-toolsai.jupyter-2025.2.0.vsix
-5d3f3fb56c004dda88ef6fb636d80270ce687407d78c1b27c66242d9b6e4628e
+https://open-vsx.org/api/ms-toolsai/jupyter/2025.3.0/file/ms-toolsai.jupyter-2025.3.0.vsix
+f9c1bc5a9cdc28c1696655cba7bc2906782c7f995124b170eb974303a826a356
 
 # yaml extension by redhat
-https://open-vsx.org/api/redhat/vscode-yaml/1.15.0/file/redhat.vscode-yaml-1.15.0.vsix
-36194b35826bc8a291bfea8f58e8fdea94f6c1f92241ea848a9dbbaf39760b43
+https://open-vsx.org/api/redhat/vscode-yaml/1.17.0/file/redhat.vscode-yaml-1.17.0.vsix
+bb7b262e4e72093f4332d167af1879b4a6df0d0d976cbe9b9766d718e0f7f17d
 
 # If you have additional extensions, you may put them here, following the
 # same format. The download_vscode.sh script will download them, and the


### PR DESCRIPTION
IMPORTANT test note: if you are still using expired SSL certificates but just telling the browser to ignore it, notebook support within VSCode will not work. Make sure your local SSL certificates are up to date, therefore, before testing this